### PR TITLE
exit phantom process when processing is done

### DIFF
--- a/phantomjs/bridge.js
+++ b/phantomjs/bridge.js
@@ -73,8 +73,9 @@ page.open(url, function (status) {
         break;
         default:
             sendMessage("console", 'Unknown standard.');
-            phantom.exit();
         break;
     }
+
+    phantom.exit();
 });
 


### PR DESCRIPTION
Just figured it out, I want to resolve #7. PhantomJS process need to be closed always when processing is done, not just if there's unknown standard.
