### PR TITLE
Pass in urls instead of files

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,9 @@ accessibility: {
     accessibilityLevel: 'WCAG2A'
   },
   test: {
+    options: {
+      urls: ['http://localhost']
+    },
     src: ['example/test.html']
   }
 }

--- a/tasks/grunt-accessibility.js
+++ b/tasks/grunt-accessibility.js
@@ -12,7 +12,7 @@ module.exports = function(grunt) {
     var options = this.options({});
 
     accessSniff
-      .default(this.filesSrc, options)
+      .default(options.urls || this.filesSrc, options)
       .then(function(report) {
         if (options.reportLocation) {
           accessSniff.report(report, {


### PR DESCRIPTION
I couldn't see a way of passing in urls instead of files to test accessibility. Apologies if there is an obvious way of doing this already but I just couldn't see it.

I forked and created a branch with a possible solution by passing in an array of url/s in the options for consideration.