### PR TITLE
Fix the report option "reportLocation"

### DIFF
--- a/tasks/grunt-accessibility.js
+++ b/tasks/grunt-accessibility.js
@@ -16,7 +16,7 @@ module.exports = function(grunt) {
       .then(function(report) {
         if (options.reportLocation) {
           accessSniff.report(report, {
-            location: options.reportLocation,
+            reportLocation: options.reportLocation,
             reportType: options.reportType
           });
         }


### PR DESCRIPTION
Public interface of AccessSniff describes "reportLocation"; not "location".

Fixes the Grunt task after fixing the public interface in AccessSniff - [PR 42](https://github.com/yargalot/AccessSniff/pull/42).